### PR TITLE
Argparsing and executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool compresses a 128x32 pixel bitmap generated with [img2cpp](https://javl
 One of the most popular [NIBBLE keymaps](https://github.com/qmk/qmk_firmware/tree/master/keyboards/nullbitsco/nibble/keymaps/oled_bongocat) was too large to enable VIA on. The frames had a lot of whitespace and compressing them seemed like a promising idea. The firmware-side decompression algorithm is very simple, takes up only a few bytes of flash, and fast enough that it doesn't noticeably slow down the matrix scan. After compressing the 7 original frames, there is over 1kB of free flash remaining for other cool firmware features, or the addition of extra frames for more complex animations. 
 
 ## Usage
-Generate a 128x32 byte array using img2cpp (black background, plain bytes, Vertical - 1 bit per pixel) and save only the raw bytes to `input_bytes.tmp`. Run
+Generate a 128x32 byte array using img2cpp (black background, plain bytes, Vertical - 1 bit per pixel) and save only the raw bytes to `input_bytes.tmp`. Optionally, users may save the raw bytes to another file of their choosing and use the `-f` flag followed by their file name when running the program. Run
 `python3 squeez-o.py` and copy the output `block_list` and `block_maps` into your keymap or keyboard code. For projects with multiple animations, do this for each frame.
 
 Within the keyboard firmware, use the example decompression algorithm in `decompress.c` to decompress the `block_list` and `block_maps` and write to the OLED display. 

--- a/squeez-o.py
+++ b/squeez-o.py
@@ -1,7 +1,16 @@
+#!/usr/bin/env python3
 # Compress bitmaps using clever encoding
 # Works only with 128x32 (512 bytes long) BMPs for now.
 
+from ast import arg
 import textwrap
+import argparse
+
+# Arg parser
+parser = argparse.ArgumentParser()
+parser.add_argument('-f', '--file', action='store', help='file to run the squeeze-o compression algorithm on [default = input_bytes.tmp]', default='input_bytes.tmp', type=str)
+args = parser.parse_args()
+
 my_wrap = textwrap.TextWrapper(width = 95)
 
 # TODO: This could also be modified to work with other dominant bytes: 0xFF for example.
@@ -12,7 +21,7 @@ def chunkstring(string, length):
     return (string[0+i:length+i] for i in range(0, len(string), length))
 
 # Read into individual bytes
-with open('input_bytes.tmp') as fo:
+with open(args.file) as fo:
     bytes_raw = fo.read()
 
 # Clean


### PR DESCRIPTION
Simple edits to make the program accept other files than just input_bytes.tmp. The program will still default to this file if no file is provided in the arguments. Updated the readme to reflect this change.  